### PR TITLE
특정 액션 기다리는 미들웨어 추가

### DIFF
--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import reducer from 'store/reducer';
 import { MakeStoreOptions } from 'next-redux-wrapper';
@@ -6,11 +6,14 @@ import rootSaga from 'saga';
 
 const cs = (initialState: StoreState, { isServer, req }: MakeStoreOptions) => {
   const sagaMiddleware = createSagaMiddleware();
+  const composeEnhancers =
+    (!isServer && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) ||
+    compose;
 
   const store = createStore(
     reducer,
     initialState,
-    applyMiddleware(sagaMiddleware),
+    composeEnhancers(applyMiddleware(sagaMiddleware)),
   );
 
   if (req || !isServer) {

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,9 +1,10 @@
 import { createStore, applyMiddleware } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import reducer from 'store/reducer';
+import { MakeStoreOptions } from 'next-redux-wrapper';
 import rootSaga from 'saga';
 
-const cs = (initialState: StoreState) => {
+const cs = (initialState: StoreState, { isServer, req }: MakeStoreOptions) => {
   const sagaMiddleware = createSagaMiddleware();
 
   const store = createStore(
@@ -12,7 +13,9 @@ const cs = (initialState: StoreState) => {
     applyMiddleware(sagaMiddleware),
   );
 
-  (store as any).sagaTask = sagaMiddleware.run(rootSaga);
+  if (req || !isServer) {
+    (store as any).sagaTask = sagaMiddleware.run(rootSaga);
+  }
 
   return store;
 };

--- a/src/utils/resolveMiddleware.ts
+++ b/src/utils/resolveMiddleware.ts
@@ -1,0 +1,43 @@
+import { Middleware, Action } from 'redux';
+
+type ResolveFn = (value?: any) => void;
+type WaitingAction = {
+  type: string;
+  resolve: ResolveFn;
+};
+
+const createMiddleware = () => {
+  let waitingActions: WaitingAction[] = [];
+
+  const resolver = (action: Action) => {
+    const needToResolve: ResolveFn[] = [];
+    waitingActions = waitingActions.filter(({ type, resolve }) => {
+      if (type === action.type) {
+        needToResolve.push(resolve);
+        return false;
+      }
+      return true;
+    });
+    needToResolve.forEach(resolve => resolve(action));
+  };
+
+  const middleware: Middleware = () => next => action => {
+    const returnValue = next(action);
+    resolver(action);
+    return returnValue;
+  };
+
+  async function waitAction<T extends Action>(type: T['type']) {
+    const action = await new Promise<T>(resolve =>
+      waitingActions.push({ type, resolve }),
+    );
+    return action;
+  }
+
+  return [middleware, waitAction] as const;
+};
+
+const [middleware, waitAction] = createMiddleware();
+
+export { middleware, waitAction };
+export default middleware;


### PR DESCRIPTION
- redux devtool 연결
- saga 미들웨어 서버, 클라이언트 한번씩만 호출되도록 수정
  - 기존에는 서버에서 `getIntialProps` 일때 한번, 서버에서 랜더할때 한번, 클라이언트에서 랜더할때 한번 총 3번호출됨
  - `if (req !! !isServer)` 로 수정
-  특정 액션 기다리는 미들웨어 추가
현재 사가  사용방식으로는 범준이형이 말한대로
`END` 가 사가 기본 채널을 끝내버리기 때문에
비동기 작업의 완료 액션을 받아서 처리하는 로직을 만들 수 없음.
위 작업이 필요한 경우가 많지도 않을거고 없는게 젤 좋겠지만 (SSR이기 때문에 연속적인 작업이 모두 끝나기 전까지 빈화면이 나오기 때문에 안좋음) 필요한 경우가 있을수도 있어서 그때 사용할 수 있는 미들웨어 추가
